### PR TITLE
Add description to set indent-tabs-mode to nil

### DIFF
--- a/firrtl-mode.el
+++ b/firrtl-mode.el
@@ -158,6 +158,7 @@ repeated key presses."
 
   ;; Set everything up
   (setq font-lock-defaults '(firrtl-font-lock-keywords))
+  (setq indent-tabs-mode nil)
   (setq-local indent-line-function 'firrtl-cycle-indents)
   (set-syntax-table firrtl-table)
   (setq-local comment-start ";")


### PR DESCRIPTION
For now, FIRRTL cannot treat tabs as indent correctly.
For example, if code uses tabs for indent, firrtl parser causes parse errors.
This change insert space characters instead of tabs to add indent in firrtl-mode.